### PR TITLE
Changed git pull to git clone in build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Contributing
 Droplet uses Grunt and npm to build. Run:
 
 ```shell
-git pull https://github.com/dabbler0/droplet.git
+git clone https://github.com/dabbler0/droplet.git
 cd droplet
 npm install
 grunt all


### PR DESCRIPTION
During building, it needs to clone the repository for the first time. Git pull is just to pull the new commits from remote to existing local repository.
